### PR TITLE
Fix bug in parser, apparently AWS likes to update log format without notice

### DIFF
--- a/bushwack/parser.go
+++ b/bushwack/parser.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-var InvalidLogFormat = errors.New("Invalid log format, expecting 20 fields")
+var InvalidLogFormat = errors.New("Invalid log format, expecting >=20 fields")
 var ClosingQuoteNotFound = errors.New("Closing quote not found in line")
 
 func ProcessLog(filename string) (int, string, error) {
@@ -78,7 +78,7 @@ func parseLine(line string) ([]string, error) {
 		return nil, err
 	}
 
-	if len(args) != 20 {
+	if len(args) < 20 {
 		return nil, InvalidLogFormat
 	}
 


### PR DESCRIPTION
New log entries contain a 0 at the end of the line... not sure what this if for, but it breaks the assertion on 20 components in a line.